### PR TITLE
Adding redirect for Docker

### DIFF
--- a/000-default.conf
+++ b/000-default.conf
@@ -1,0 +1,37 @@
+<VirtualHost *:80>                                                                                
+        # The ServerName directive sets the request scheme, hostname and port that                
+        # the server uses to identify itself. This is used when creating                          
+        # redirection URLs. In the context of virtual hosts, the ServerName                       
+        # specifies what hostname must appear in the request's Host: header to                    
+        # match this virtual host. For the default virtual host (this file) this                  
+        # value is not decisive as it is used as a last resort host regardless.                   
+        # However, you must set it for any further virtual host explicitly.                       
+        #ServerName www.example.com                                                               
+                                                                                                  
+        ServerAdmin webmaster@localhost                                                           
+        DocumentRoot /var/www/html                                                                
+                                                                                                  
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,                    
+        # error, crit, alert, emerg.                                                              
+        # It is also possible to configure the loglevel for particular                            
+        # modules, e.g.                                                                           
+        #LogLevel info ssl:warn                                                                   
+                                                                                                  
+        ErrorLog ${APACHE_LOG_DIR}/error.log                                                      
+        CustomLog ${APACHE_LOG_DIR}/access.log combined                                           
+
+        <IfModule dir_module>
+            DirectoryIndex index.html web_get_iplayer.py
+        </IfModule>
+        RewriteEngine On
+        RewriteRule ^/$ /cgi-bin/ [R]
+                                                                                                  
+        # For most configuration files from conf-available/, which are                            
+        # enabled or disabled at a global level, it is possible to                                
+        # include a line for only one particular virtual host. For example the                    
+        # following line enables the CGI configuration for this host only                         
+        # after it has been globally disabled with "a2disconf".                                   
+        #Include conf-available/serve-cgi-bin.conf                                                
+</VirtualHost>                                                                                    
+                                                                                                  
+ServerName web_get_iplayer       

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM debian:latest
 MAINTAINER Christian Ashby <docker@cashby.me.uk>
 # Install OS package prerequisites and configure apache
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y screen apache2 python python-psutil wget build-essential cron rsyslog git && \
+    apt-get install -y apache2 python python-psutil wget build-essential cron rsyslog git && \
     mkdir /var/lock/apache2 && \
     a2enmod cgi && \
+    a2enmod rewrite && \
     echo "ServerName web_get_iplayer" >> /etc/apache2/sites-enabled/000-default.conf
 RUN apt-get update && \
     apt-get install -y ffmpeg rtmpdump 
@@ -23,6 +24,7 @@ RUN chmod +x web_get_iplayer.py
 COPY web_get_iplayer.cron.sh .
 RUN chmod +x web_get_iplayer.cron.sh
 COPY _etc_cron.d_web_get_iplayer /etc/cron.d/web_get_iplayer 
+COPY 000-default.conf /etc/apache2/sites-available/000-default.conf
 RUN chmod g-w /etc/cron.d/web_get_iplayer
 # Configure web_get_iplayer
 WORKDIR /var/lib


### PR DESCRIPTION
Added Apache sites config to enable rewriting of / to the web_get_iplayer.py page.

Also cleaned up 'screen' which was unused in the install script.